### PR TITLE
Add a layout test.

### DIFF
--- a/lib/chalk-log/layout.rb
+++ b/lib/chalk-log/layout.rb
@@ -123,7 +123,7 @@ class Chalk::Log::Layout < ::Logging::Layout
     id, important, bad = interpret_meta(level, meta)
 
     tags = []
-    tags << $$ unless tag_without_pid
+    tags << Process.pid unless tag_without_pid
     tags << id if id
     if tags.length > 0
       prefix = "[#{tags.join('|')}] "

--- a/test/functional/log.rb
+++ b/test/functional/log.rb
@@ -269,14 +269,18 @@ module Critic::Functional
     it 'log entry from info' do
       event = stub(:data => ["A Message", {:key1 => "ValueOne", :key2 => ["An", "Array"]}], :time => Time.new(1979,4,9), :level => 1)
       Process.stubs(:pid).returns(9973)
-      assert_equal(layout.format(event), '[1979-04-09 00:00:00.000000] [9973] A Message: key1="ValueOne" key2=["An","Array"]' + "\n")
+      assert_equal('[1979-04-09 00:00:00.000000] [9973] A Message: key1="ValueOne" key2=["An","Array"]' + "\n", 
+        layout.format(event)
+      )
     end
 
     it 'log entry from error without a backtrace' do
       event = stub(:data => ["Another Message", StandardError.new], :time => Time.new(1979,4,9), :level => 3)
       Process.stubs(:pid).returns(9973)
-      assert_equal(layout.format(event), '[1979-04-09 00:00:00.000000] [9973] Another Message: StandardError (StandardError)' +
-        "\n" + '[1979-04-09 00:00:00.000000] [9973]   (no backtrace)' + "\n")
+      assert_equal('[1979-04-09 00:00:00.000000] [9973] Another Message: StandardError (StandardError)' +
+        "\n" + '[1979-04-09 00:00:00.000000] [9973]   (no backtrace)' + "\n",
+        layout.format(event)
+      )
     end
 
     it 'log entry from error with a backtrace' do
@@ -285,9 +289,11 @@ module Critic::Functional
       error.set_backtrace(backtrace)
       event = stub(:data => ["Yet Another Message", error], :time => Time.new(1979,4,9), :level => 3)
       Process.stubs(:pid).returns(9973)
-      assert_equal(layout.format(event), '[1979-04-09 00:00:00.000000] [9973] Yet Another Message: StandardError (StandardError)' +
+      assert_equal('[1979-04-09 00:00:00.000000] [9973] Yet Another Message: StandardError (StandardError)' +
         "\n" + '[1979-04-09 00:00:00.000000] [9973]   a fake' +
-        "\n" + '[1979-04-09 00:00:00.000000] [9973]   backtrace' + "\n")
+        "\n" + '[1979-04-09 00:00:00.000000] [9973]   backtrace' + "\n",
+        layout.format(event)
+      )
     end
   end
 end

--- a/test/functional/log.rb
+++ b/test/functional/log.rb
@@ -259,4 +259,35 @@ module Critic::Functional
       assert(true)
     end
   end
+  describe 'generates a pretty_print' do
+    class PrettyPrintLogger
+      include Chalk::Log
+    end
+
+    layout = PrettyPrintLogger::Layout.new
+
+    it 'log entry from info' do
+      event = stub(:data => ["A Message", {:key1 => "ValueOne", :key2 => ["An", "Array"]}], :time => Time.new(1979,4,9), :level => 1)
+      Process.stubs(:pid).returns(9973)
+      assert_equal(layout.format(event), '[1979-04-09 00:00:00.000000] [9973] A Message: key1="ValueOne" key2=["An","Array"]' + "\n")
+    end
+
+    it 'log entry from error without a backtrace' do
+      event = stub(:data => ["Another Message", StandardError.new], :time => Time.new(1979,4,9), :level => 3)
+      Process.stubs(:pid).returns(9973)
+      assert_equal(layout.format(event), '[1979-04-09 00:00:00.000000] [9973] Another Message: StandardError (StandardError)' +
+        "\n" + '[1979-04-09 00:00:00.000000] [9973]   (no backtrace)' + "\n")
+    end
+
+    it 'log entry from error with a backtrace' do
+      error = StandardError.new
+      backtrace = ["a fake", "backtrace"]
+      error.set_backtrace(backtrace)
+      event = stub(:data => ["Yet Another Message", error], :time => Time.new(1979,4,9), :level => 3)
+      Process.stubs(:pid).returns(9973)
+      assert_equal(layout.format(event), '[1979-04-09 00:00:00.000000] [9973] Yet Another Message: StandardError (StandardError)' +
+        "\n" + '[1979-04-09 00:00:00.000000] [9973]   a fake' +
+        "\n" + '[1979-04-09 00:00:00.000000] [9973]   backtrace' + "\n")
+    end
+  end
 end


### PR DESCRIPTION
@gdb this is just here so we can compare the old log format to the pretty_print format. They should be virtually identical. (they aren't quite because the old format quoted everything in info)
