### PR TITLE
Use stderr to check tty for timestamp config.

### DIFF
--- a/lib/chalk-log/config.rb
+++ b/lib/chalk-log/config.rb
@@ -1,7 +1,7 @@
 # TODO: this module should go away, to be replaced by configatron
 module Chalk::Log::Config
   @config = {
-    :tag_with_timestamp => STDOUT.tty?,
+    :tag_with_timestamp => STDERR.tty?,
     :default_level => 'INFO',
     :output_format => 'pp'
   }


### PR DESCRIPTION
We write logs to stderr but check whether stdout is a tty when deciding
whether to print timestamps. Unify on stderr instead.

@gdb 
