### PR TITLE
"contextual info": contextual logging of key-value pairs

### DIFF
--- a/lib/chalk-log.rb
+++ b/lib/chalk-log.rb
@@ -77,7 +77,7 @@ module Chalk::Log
   # Public-facing initialization method for all `Chalk::Log`
   # state. Unlike most other Chalk initializers, this will be
   # automatically run (invoked on first logger instantiation). It is
-  # impotent.
+  # idempotent.
   def self.init
     return if @init
     @init = true

--- a/lib/chalk-log/layout.rb
+++ b/lib/chalk-log/layout.rb
@@ -67,7 +67,7 @@ class Chalk::Log::Layout < ::Logging::Layout
       action_id: id,
       message: message,
       error: error,
-      info: info,
+      info: (info && info.merge(contextual_info || {})) || contextual_info,
       pid: pid
       )
   end
@@ -108,7 +108,7 @@ class Chalk::Log::Layout < ::Logging::Layout
   # Displaying info hash
 
   def info!(message, info)
-    message << format_hash(info)
+    message << format_hash(info.merge(contextual_info || {}))
   end
 
   def display(key, value)
@@ -158,6 +158,10 @@ class Chalk::Log::Layout < ::Logging::Layout
 
   def action_id
     LSpace[:action_id]
+  end
+
+  def contextual_info
+    LSpace[:'chalk.log.contextual_info']
   end
 
   def tag(message, time, pid, action_id)

--- a/lib/chalk-log/logger.rb
+++ b/lib/chalk-log/logger.rb
@@ -49,6 +49,11 @@ class Chalk::Log::Logger
     unless blk
       raise ArgumentError.new("Must pass a block to #{__method__}")
     end
+    unless contextual_info.is_a?(Hash)
+      raise TypeError.new(
+        "contextual_info must be a Hash, but got #{contextual_info.class}"
+      )
+    end
     existing_context = LSpace[:'chalk.log.contextual_info'] || {}
     LSpace.with(
       :'chalk.log.contextual_info' => contextual_info.merge(existing_context),

--- a/lib/chalk-log/logger.rb
+++ b/lib/chalk-log/logger.rb
@@ -44,4 +44,15 @@ class Chalk::Log::Logger
   def logging_disabled?
     configatron.chalk.log.disabled || LSpace[:'chalk.log.disabled']
   end
+
+  def with_contextual_info(contextual_info={}, &blk)
+    unless blk
+      raise ArgumentError.new("Must pass a block to #{__method__}")
+    end
+    existing_context = LSpace[:'chalk.log.contextual_info'] || {}
+    LSpace.with(
+      :'chalk.log.contextual_info' => contextual_info.merge(existing_context),
+      &blk
+    )
+  end
 end

--- a/test/functional/log.rb
+++ b/test/functional/log.rb
@@ -207,6 +207,13 @@ module Critic::Functional
           end
           assert_includes(exn.message, "Must pass a block")
         end
+
+        it 'requires its argument must be a hash' do
+          exn = assert_raises(TypeError) do
+            log.with_contextual_info('not a hash') {}
+          end
+          assert_includes(exn.message, 'must be a Hash')
+        end
       end
     end
 

--- a/test/functional/log.rb
+++ b/test/functional/log.rb
@@ -4,6 +4,17 @@ require 'chalk-log'
 
 module Critic::Functional
   class LogTest < Test
+    def self.add_appender
+      unless @appender
+        @appender = ::Logging.appenders.string_io(
+          'test-stringio',
+          layout: Chalk::Log.layout
+        )
+        ::Logging.logger.root.add_appenders(@appender)
+      end
+      @appender
+    end
+
     before do
       Chalk::Log.init
     end
@@ -157,6 +168,11 @@ module Critic::Functional
       before do
         TestLogInstanceMethods.log.level = 'INFO'
         Chalk::Log.init
+        @appender = LogTest.add_appender
+      end
+
+      def assert_logged(expected_string, *args)
+        assert_includes(@appender.sio.string, expected_string, *args)
       end
 
       it 'accepts blocks on instance methods' do
@@ -164,6 +180,33 @@ module Critic::Functional
         log.debug { assert(false, "DEBUG block called at INFO") }
         log.info { called = true; "" }
         assert(called, "INFO block not called at INFO level")
+      end
+
+      describe 'when contextual info is set' do
+
+        it 'adds contextual information to `.info` log lines' do
+          log.with_contextual_info(key: 'value') {log.info("message")}
+          assert_logged("key=value")
+        end
+
+        it 'nests contexts' do
+          log.with_contextual_info(top_key: "top_value") do
+            log.info("top message")
+            log.with_contextual_info(inner_key: "inner_value") do
+              log.info("inner message")
+            end
+          end
+          %w{top_key=top_value inner_key=inner_value}.each do |pair|
+            assert_logged(pair)
+          end
+        end
+
+        it 'requires a block' do
+          exn = assert_raises(ArgumentError) do
+            log.with_contextual_info(i_am_not: "passing a block")
+          end
+          assert_includes(exn.message, "Must pass a block")
+        end
       end
     end
 


### PR DESCRIPTION
When the Stripe Ops team processes a large number of records in succession, we would like to have a way to group log lines for those records together.

This pull request introduces the notion of "contextual info" -- information which is logged within a dynamic context, as key-value pairs inserted into every `log.info` call.

r? @canderson 
