### PR TITLE
Add truncation method

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,3 +17,6 @@ chalk:
 
     # Whether to show logs at all
     disabled: false
+
+    # Whether to remove gem lines from backtraces
+    compress_backtraces: false

--- a/lib/chalk-log/utils.rb
+++ b/lib/chalk-log/utils.rb
@@ -13,6 +13,7 @@ module Chalk::Log::Utils
   def self.format_backtrace(backtrace)
     if configatron.chalk.log.compress_backtraces
       backtrace = compress_backtrace(backtrace)
+      backtrace << '(Disable backtrace compression by setting configatron.chalk.log.compress_backtraces = false.)'
     end
 
     "  " + backtrace.join("\n  ")

--- a/lib/chalk-log/utils.rb
+++ b/lib/chalk-log/utils.rb
@@ -11,7 +11,10 @@ module Chalk::Log::Utils
   #
   # TODO: add autotruncating of backtraces.
   def self.format_backtrace(backtrace)
-    backtrace = truncate(backtrace)
+    if configatron.chalk.log.compress_backtraces
+      backtrace = compress_backtrace(backtrace)
+    end
+
     "  " + backtrace.join("\n  ")
   end
 
@@ -39,8 +42,9 @@ module Chalk::Log::Utils
     exploded
   end
 
-  def self.truncate(backtrace)
-    truncated = []
+  # Compresses a backtrace
+  def self.compress_backtrace(backtrace)
+    compressed = []
     gemdir = Gem.dir
 
     hit_application = false
@@ -52,7 +56,7 @@ module Chalk::Log::Utils
         # first three lines if we haven't seen any application lines
         # yet.
         if !hit_application && leading_lines < 3
-          truncated << line
+          compressed << line
           leading_lines += 1
         else
           gemlines += 1
@@ -60,17 +64,17 @@ module Chalk::Log::Utils
       elsif gemlines > 0
         # If we were in a gem and now are not, record the number of
         # lines skipped.
-        truncated << "<#{gemlines} #{gemlines == 1 ? 'line' : 'lines'} omitted>"
-        truncated << line
+        compressed << "<#{gemlines} #{gemlines == 1 ? 'line' : 'lines'} omitted>"
+        compressed << line
         hit_application = true
         gemlines = 0
       else
         # If we're in the application, always record the line.
-        truncated << line
+        compressed << line
         hit_application = true
       end
     end
 
-    truncated
+    compressed
   end
 end

--- a/lib/chalk-log/utils.rb
+++ b/lib/chalk-log/utils.rb
@@ -42,12 +42,15 @@ module Chalk::Log::Utils
     exploded
   end
 
-  # Compresses a backtrace
+  # Compresses a backtrace, omitting gem lines (unless they appear
+  # before any application lines).
   def self.compress_backtrace(backtrace)
     compressed = []
     gemdir = Gem.dir
 
     hit_application = false
+    # This isn't currently read by anything, but we could easily use
+    # it to limit the number of leading gem lines.
     leading_lines = 0
     gemlines = 0
     backtrace.each do |line|
@@ -55,7 +58,7 @@ module Chalk::Log::Utils
         # If we're in a gem, always increment the counter. Record the
         # first three lines if we haven't seen any application lines
         # yet.
-        if !hit_application && leading_lines < 3
+        if !hit_application
           compressed << line
           leading_lines += 1
         else


### PR DESCRIPTION
Example:

```
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/manage/srv.rb:1541:in `block (2 levels) in <class:ManageServer>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/db/model/account_application.rb:1573:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/db/model/account_application.rb:1573:in `block in with_lock'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <3 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/db/model/abstract_model.rb:133:in `update'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/db/model/account_application.rb:1571:in `with_lock'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/manage/srv.rb:1539:in `block in <class:ManageServer>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <22 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/referer_manager.rb:15:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <11 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/manage/lib/middleware/best_standards_support.rb:11:in `block in <class:BestStandardsSupport>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <10 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/timeout_handler.rb:52:in `block in <class:TimeoutHandler>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <10 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/merchant_sharding.rb:15:in `block in <class:MerchantSharding>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <10 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/manage/lib/middleware/manage_error_handler.rb:14:in `block in <class:ManageErrorHandler>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <10 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/abstract_reporter.rb:31:in `block in <class:AbstractReporter>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <10 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/endpoint_filter.rb:14:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/csrf_protector.rb:61:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/session_authenticator.rb:26:in `block in call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <3 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/session_authenticator.rb:26:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/risk/lib/middleware/sanctioned_country_blocks.rb:49:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <5 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/sprockets_server.rb:26:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/periodic_poller.rb:12:in `call'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <35 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/middleware/wabbit_confirmer.rb:12:in `block in <class:WabbitConfirmer>'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <88 lines omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/lib/srv_common/abstract_stripe_server.rb:76:in `run!'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   <1 line omitted>
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/manage/srv.rb:2554:in `main'
[17:56:21] manage          : [30284|qa-dev1.stripe.io/QRVE-5VQR8-1]   /pay/home/gdb/dev-gdb/pay-server/dev/lib/dev_plan.rb:140:in `block in load_and_start_service'
```
