### PR TITLE
Add support for a dynamic message prefix

### DIFF
--- a/lib/chalk-log.rb
+++ b/lib/chalk-log.rb
@@ -104,6 +104,15 @@ module Chalk::Log
     @layout ||= Chalk::Log::Layout.new
   end
 
+  # Adds a prefix to all logging within the current LSpace context.
+  def self.with_message_prefix(prefix, &blk)
+    LSpace.with(:'chalk.log.message_prefix' => prefix, &blk)
+  end
+
+  def self.message_prefix
+    LSpace[:'chalk.log.message_prefix']
+  end
+
   # Home of the backend `log` method people call; included *and*
   # extended everywhere that includes Chalk::Log.
   module ClassMethods

--- a/lib/chalk-log/layout.rb
+++ b/lib/chalk-log/layout.rb
@@ -87,6 +87,11 @@ class Chalk::Log::Layout < ::Logging::Layout
       message << ':'
     end
 
+    if Chalk::Log.message_prefix
+      message ||= ''
+      message.prepend(Chalk::Log.message_prefix)
+    end
+
     if info
       message << ' ' if message
       message ||= ''

--- a/lib/chalk-log/version.rb
+++ b/lib/chalk-log/version.rb
@@ -1,5 +1,5 @@
 module Chalk
   module Log
-    VERSION = '0.1.3'
+    VERSION = '0.1.4'
   end
 end

--- a/test/functional/formatting.rb
+++ b/test/functional/formatting.rb
@@ -78,6 +78,13 @@ module Critic::Functional
         assert_equal('[9973] A Message: key1=ValueOne key2=["An","Array"]', rendered)
       end
 
+      it 'logs the message_prefix correctly' do
+        Chalk::Log.with_message_prefix('PREFIX: ') do
+          rendered = layout(data: ["A Message", {:key1 => "ValueOne", :key2 => ["An", "Array"]}])
+          assert_equal('[9973] PREFIX: A Message: key1=ValueOne key2=["An","Array"]', rendered)
+        end
+      end
+
       it 'logs the action_id correctly' do
         LSpace.with(action_id: 'action') do
           rendered = layout(data: ["A Message", {:key1 => "ValueOne", :key2 => ["An", "Array"]}])


### PR DESCRIPTION
**Motivation**
When using threads, this enables all log lines from a given thread to get prefixed (with, for example, the type of job the thread is running, and/or the thread id).

r? @metcalf 
cc @stripe/product-infra 
