### PR TITLE
Add a configuration flag to completely disable printing backtraces

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,3 +20,6 @@ chalk:
 
     # Whether to remove gem lines from backtraces
     compress_backtraces: false
+
+    # Whether to display backtraces at all
+    display_backtraces: true

--- a/lib/chalk-log/layout.rb
+++ b/lib/chalk-log/layout.rb
@@ -133,9 +133,11 @@ class Chalk::Log::Layout < ::Logging::Layout
     backtrace = error.backtrace || ['[no backtrace]']
     message << display(:error_class, error.class.to_s) << " "
     message << display(:error, error.to_s)
-    message << "\n"
-    message << Chalk::Log::Utils.format_backtrace(backtrace)
-    message << "\n"
+    if configatron.chalk.log.display_backtraces
+      message << "\n"
+      message << Chalk::Log::Utils.format_backtrace(backtrace)
+      message << "\n"
+    end
     message
   end
 

--- a/test/functional/formatting.rb
+++ b/test/functional/formatting.rb
@@ -28,6 +28,12 @@ module Critic::Functional
       end
     end
 
+    def disable_backtraces
+      configatron.unlock! do
+        configatron.chalk.log.display_backtraces = false
+      end
+    end
+
     before do
       Chalk::Log.init
       Process.stubs(:pid).returns(9973)
@@ -123,6 +129,16 @@ module Critic::Functional
 
         rendered = layout(data: ["Yet Another Message", error])
         assert_equal("[9973] Yet Another Message: error_class=StandardError error=msg\n[9973]   a fake\n[9973]   backtrace", rendered)
+      end
+
+      it 'hides backtraces when they are disabled' do
+        error = StandardError.new('msg')
+        backtrace = ["a fake", "backtrace"]
+        error.set_backtrace(backtrace)
+
+        disable_backtraces
+        rendered = layout(data: ['Even more messages', error])
+        assert_equal('[9973] Even more messages: error_class=StandardError error=msg', rendered)
       end
 
       it 'renders an error passed alone' do


### PR DESCRIPTION
In general, backtraces are really long and noisy, and using logs as a
means of diagnosing bugs instead of some sort of exception tracker is
never a particularly good idea.

We could move away from passing backtraces to chalk-log entirely, but
the automatic rendering of error_class and error are useful.

r? @kiran
