### PR TITLE
Add global default log level configuration to Chalk::Log

### DIFF
--- a/lib/chalk-log.rb
+++ b/lib/chalk-log.rb
@@ -113,6 +113,25 @@ module Chalk::Log
     LSpace[:'chalk.log.message_prefix']
   end
 
+  def self.level=(lvl)
+    _root_backend.level = lvl
+  end
+
+  def self.level
+    _root_backend.level
+  end
+
+  # This should only be called from Chalk::Log::Logger
+  def self._root_backend
+    @root_backend ||= begin
+      backend = ::Logging::Logger.new("CHALK_LOG_ROOT")
+      if (level = configatron.chalk.log.default_level)
+        backend.level = level
+      end
+      backend
+    end
+  end
+
   # Home of the backend `log` method people call; included *and*
   # extended everywhere that includes Chalk::Log.
   module ClassMethods

--- a/lib/chalk-log/logger.rb
+++ b/lib/chalk-log/logger.rb
@@ -3,10 +3,16 @@
 class Chalk::Log::Logger
   attr_reader :backend
 
+  ROOT_LOGGER_NAME = "CHALK_LOG_ROOT".freeze
+  private_constant :ROOT_LOGGER_NAME
+
   # Initialization of the logger backend. It does the actual creation
   # of the various logger methods. Will be called automatically upon
   # your first `log` method call.
   def self.init
+    return if @initialized
+    @initialized = true
+
     Chalk::Log::LEVELS.each do |level|
       define_method(level) do |*data, &blk|
         return if logging_disabled?
@@ -33,10 +39,10 @@ class Chalk::Log::Logger
     # Chalk::Log to be usable anytime during the boot process, which
     # requires being a little bit less explicit than we usually like.
     Chalk::Log.init
+
+    # The Logging library parses the logger name to determine the correct parent
+    name = Chalk::Log._root_backend.name + ::Logging::Repository::PATH_DELIMITER + (name || 'ANONYMOUS')
     @backend = ::Logging::Logger.new(name)
-    if level = configatron.chalk.log.default_level
-      @backend.level = level
-    end
   end
 
   # Check whether logging has been globally turned off, either through

--- a/lib/chalk-log/version.rb
+++ b/lib/chalk-log/version.rb
@@ -1,5 +1,5 @@
 module Chalk
   module Log
-    VERSION = '0.1.7'
+    VERSION = '0.2.0'
   end
 end

--- a/test/functional/log.rb
+++ b/test/functional/log.rb
@@ -164,6 +164,32 @@ module Critic::Functional
         LogTestE.log.info { called = true; "" }
         assert(called, "INFO block not called at INFO level")
       end
+
+      it 'respects changes to the global log level by default' do
+        begin
+          root_lvl = Chalk::Log.level
+          Chalk::Log.level = "WARN"
+
+          MyLog.log.info { assert(false, "INFO block called at WARN level") }
+        ensure
+          Chalk::Log.level = root_lvl
+        end
+      end
+
+      it 'ignores changes to the global log level when a local one is set' do
+        begin
+          root_lvl = Chalk::Log.level
+          MyLog.log.level = "INFO"
+          Chalk::Log.level = "WARN"
+
+          called = false
+          MyLog.log.info { called = true; "" }
+          assert(called, "INFO block not called at INFO level")
+        ensure
+          Chalk::Log.level = root_lvl
+          MyLog.log.level = nil
+        end
+      end
     end
 
     class TestLogInstanceMethods < Test


### PR DESCRIPTION
Currently, Chalk::Log instantiates a logger for each module when `log` is first called on that module. At instantiation, it sets the log level to `configatron.chalk.log.default_level`. This means that if you want to set a different global log level, you either need to do it before `log` is called or do it for each module individually. Both are error prone and difficult.

This adds a new logger at the root of the logging hierarchy where we set the configatron default log level once. You can override the global default at any time with `Chalk::Log.level = <level>`. All modules that haven't set an explicit log level (or have explicitly set their level to `nil`) will respect the global default.

This also causes our log levels to respect the existing logger hierarchy. So if you have `Chalk::Log` in `Foo` and `Foo::Bar` and set `Foo.level = :debug`, `Bar` will inherit that configuration unless it explicitly overrides it.

This also fixes a bug whereby `log` in anonymous classes and modules was mutating the log level on the root logger.