### PR TITLE
Add statically-defined constants for criticality levels

### DIFF
--- a/lib/chalk-log.rb
+++ b/lib/chalk-log.rb
@@ -37,10 +37,10 @@ module Chalk::Log
   LEVELS = [:debug, :info, :warn, :error, :fatal].freeze
 
   module CLevels
-    Sheddable = 'sheddable'
-    SheddablePlus = 'sheddableplus'
-    Critical = 'critical'
-    CriticalPlus = 'criticalplus'
+    Sheddable = :sheddable
+    SheddablePlus = :sheddableplus
+    Critical = :critical
+    CriticalPlus = :criticalplus
   end
 
   @included = Set.new

--- a/lib/chalk-log.rb
+++ b/lib/chalk-log.rb
@@ -36,7 +36,7 @@ module Chalk::Log
   # add.)
   LEVELS = [:debug, :info, :warn, :error, :fatal].freeze
 
-  module Clevels
+  module CLevels
     Sheddable = 'sheddable'
     SheddablePlus = 'sheddableplus'
     Critical = 'critical'

--- a/lib/chalk-log.rb
+++ b/lib/chalk-log.rb
@@ -36,6 +36,13 @@ module Chalk::Log
   # add.)
   LEVELS = [:debug, :info, :warn, :error, :fatal].freeze
 
+  module Clevels
+    Sheddable = 'sheddable'
+    SheddablePlus = 'sheddableplus'
+    Critical = 'critical'
+    CriticalPlus = 'criticalplus'
+  end
+
   @included = Set.new
 
   # Method which goes through heroic efforts to ensure that the whole

--- a/lib/chalk-log/version.rb
+++ b/lib/chalk-log/version.rb
@@ -1,5 +1,5 @@
 module Chalk
   module Log
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
Add statically-defined constants for criticality levels. This means that, from pay-server, we'll be able to do:

```rb
log.info("reticulate splines",
   clevel: Chalk::Log::Clevels.sheddable
)
```
instead of writing out `'sheddable'` each time. This is less typo-prone, and easier to analyze statically.

I don't think we can use `make_accessible` in `Chalk::Log`, which is why I wrote them out manually.

To pre-empt a question: In the past, Observability and Product-Infra has talked about updating Chalk's log levels to be more consistent with how we use clevels, so that there's only one concept to keep track of. Observability is still interested in doing this consolidation, but it'll require some extra thought and planning to make that change without disrupting any existing workflows. In the meantime, this gives us a single nexus point for the criticality levels in Ruby code, and having the levels defined statically will hopefully make it easier for us to do that migration when the time comes.


r? @pt-stripe 
cc @stripe/observability 