### PR TITLE
Respect precedence of contextual info

### DIFF
--- a/lib/chalk-log/logger.rb
+++ b/lib/chalk-log/logger.rb
@@ -62,7 +62,7 @@ class Chalk::Log::Logger
     end
     existing_context = LSpace[:'chalk.log.contextual_info'] || {}
     LSpace.with(
-      :'chalk.log.contextual_info' => contextual_info.merge(existing_context),
+      :'chalk.log.contextual_info' => existing_context.merge(contextual_info),
       &blk
     )
   end

--- a/test/functional/log.rb
+++ b/test/functional/log.rb
@@ -231,6 +231,16 @@ module Critic::Functional
           end
         end
 
+        it 'respects precedence of contextual info' do
+          log.with_contextual_info(nested_key: "top_value") do
+            log.info("top message")
+            log.with_contextual_info(nested_key: "inner_value") do
+              log.info("inner message")
+            end
+          end
+          assert_logged("nested_key=inner_value")
+        end
+
         it 'prefers explicit information over the context' do
           log.with_contextual_info(omg: 'wtf') do
             log.info("message", omg: 'ponies')


### PR DESCRIPTION
Nested contextual info should take precedence over an outer block when
they are using the same key. For example, in the following block, the
contextual info should be "inner" when the logger is called.

```
log.with_contextual_info(shared_key: "outer") do
  log.with_contextual_info(shared_key: "inner") do
    log.info("message")
  end
end
```

Incorrect ordering on a hash merge was causing this order not to be
respected, resulting in the topmost key cascading through and
overwriting narrower scopes. This commit reverses that merge order to
respect the set precedence.